### PR TITLE
Add live corn futures tracking via Yahoo Finance API

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,9 +5,35 @@ type HealthResponse = {
   message: string;
 };
 
+type CornPriceResponse = {
+  symbol: string;
+  price: number;
+  currency: string;
+  exchange: string;
+  previousClose: number | null;
+  timestamp: string;
+};
+
+const formatCurrency = (value: number, currency: string) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 2
+  }).format(value);
+
+const formatTimestamp = (timestamp: string) =>
+  new Date(timestamp).toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit'
+  });
+
 function App() {
   const [health, setHealth] = useState<HealthResponse | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [healthError, setHealthError] = useState<string | null>(null);
+  const [cornPrice, setCornPrice] = useState<CornPriceResponse | null>(null);
+  const [cornError, setCornError] = useState<string | null>(null);
+  const [isCornLoading, setIsCornLoading] = useState<boolean>(true);
 
   useEffect(() => {
     fetch('/api/health')
@@ -17,38 +43,154 @@ function App() {
         }
         const data: HealthResponse = await response.json();
         setHealth(data);
+        setHealthError(null);
       })
       .catch((err: Error) => {
-        setError(err.message);
+        setHealthError(err.message);
       });
   }, []);
 
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadCornPrice = async (showLoader: boolean) => {
+      if (showLoader) {
+        setIsCornLoading(true);
+      }
+
+      try {
+        const response = await fetch('/api/corn-price');
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+
+        const data: CornPriceResponse = await response.json();
+        if (!isMounted) {
+          return;
+        }
+        setCornPrice(data);
+        setCornError(null);
+      } catch (error) {
+        if (!isMounted) {
+          return;
+        }
+        setCornError(error instanceof Error ? error.message : 'Unknown error');
+      } finally {
+        if (showLoader && isMounted) {
+          setIsCornLoading(false);
+        }
+      }
+    };
+
+    loadCornPrice(true);
+    const intervalId = window.setInterval(() => loadCornPrice(false), 5000);
+
+    return () => {
+      isMounted = false;
+      window.clearInterval(intervalId);
+    };
+  }, []);
+
+  const priceChange =
+    cornPrice && cornPrice.previousClose != null
+      ? cornPrice.price - cornPrice.previousClose
+      : null;
+  const priceChangePercent =
+    priceChange != null && cornPrice?.previousClose
+      ? (priceChange / cornPrice.previousClose) * 100
+      : null;
+
   return (
-    <main style={{
-      minHeight: '100vh',
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      justifyContent: 'center',
-      fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-      padding: '2rem',
-      background: 'linear-gradient(135deg, #f0f4ff 0%, #ffffff 100%)'
-    }}>
-      <h1 style={{ fontSize: '2.5rem', marginBottom: '1rem', color: '#1f2937' }}>
-        AgentTesting Starter
+    <main
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontFamily:
+          'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        padding: '2rem',
+        background: 'linear-gradient(135deg, #f0f4ff 0%, #ffffff 100%)'
+      }}
+    >
+      <h1 style={{ fontSize: '2.5rem', marginBottom: '0.75rem', color: '#1f2937' }}>
+        Live Corn Futures Monitor
       </h1>
-      <p style={{ fontSize: '1.1rem', color: '#4b5563', maxWidth: '32rem', textAlign: 'center' }}>
-        This project pairs a lightweight Express backend with a TypeScript + React frontend powered by
-        Vite. Start both servers to see live data flowing from the API.
+      <p
+        style={{
+          fontSize: '1.1rem',
+          color: '#4b5563',
+          maxWidth: '36rem',
+          textAlign: 'center'
+        }}
+      >
+        Keep tabs on the latest Chicago Board of Trade corn futures price. The data updates
+        automatically every few seconds so you always have the freshest quote.
       </p>
-      <section style={{ marginTop: '2rem', padding: '1.5rem 2rem', borderRadius: '1rem', backgroundColor: '#fff', boxShadow: '0 20px 25px -15px rgba(15, 23, 42, 0.3)' }}>
-        <h2 style={{ marginBottom: '0.5rem', fontSize: '1.5rem', color: '#2563eb' }}>Backend status</h2>
+
+      <section
+        style={{
+          marginTop: '2rem',
+          padding: '1.75rem 2.25rem',
+          borderRadius: '1rem',
+          backgroundColor: '#fff',
+          boxShadow: '0 20px 25px -15px rgba(15, 23, 42, 0.3)',
+          maxWidth: '32rem',
+          width: '100%'
+        }}
+      >
+        <h2 style={{ marginBottom: '0.5rem', fontSize: '1.5rem', color: '#2563eb' }}>
+          CBOT Corn Futures (ZC=F)
+        </h2>
+        {isCornLoading ? (
+          <p style={{ color: '#6b7280' }}>Fetching the latest price...</p>
+        ) : cornError ? (
+          <p style={{ color: '#dc2626', fontWeight: 600 }}>Error: {cornError}</p>
+        ) : cornPrice ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+            <p style={{ fontSize: '2.25rem', fontWeight: 700, color: '#111827' }}>
+              {formatCurrency(cornPrice.price, cornPrice.currency)}
+            </p>
+            {priceChange != null && priceChangePercent != null ? (
+              <p
+                style={{
+                  fontWeight: 600,
+                  color: priceChange >= 0 ? '#16a34a' : '#dc2626'
+                }}
+              >
+                {priceChange >= 0 ? '▲' : '▼'} {priceChange.toFixed(2)} ({priceChangePercent.toFixed(2)}%)
+              </p>
+            ) : null}
+            <p style={{ color: '#4b5563' }}>
+              Exchange: {cornPrice.exchange} • Last updated at {formatTimestamp(cornPrice.timestamp)}
+            </p>
+          </div>
+        ) : (
+          <p style={{ color: '#6b7280' }}>No price data available.</p>
+        )}
+      </section>
+
+      <section
+        style={{
+          marginTop: '1.5rem',
+          padding: '1.5rem 2rem',
+          borderRadius: '1rem',
+          backgroundColor: '#fff',
+          boxShadow: '0 20px 25px -15px rgba(15, 23, 42, 0.2)',
+          maxWidth: '32rem',
+          width: '100%'
+        }}
+      >
+        <h2 style={{ marginBottom: '0.5rem', fontSize: '1.25rem', color: '#2563eb' }}>
+          Backend status
+        </h2>
         {health ? (
           <p style={{ color: '#16a34a', fontWeight: 600 }}>
             {health.status.toUpperCase()}: {health.message}
           </p>
-        ) : error ? (
-          <p style={{ color: '#dc2626', fontWeight: 600 }}>Error: {error}</p>
+        ) : healthError ? (
+          <p style={{ color: '#dc2626', fontWeight: 600 }}>Error: {healthError}</p>
         ) : (
           <p style={{ color: '#6b7280' }}>Checking backend health...</p>
         )}

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "node-fetch": "^3.3.2"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -8,6 +8,15 @@ const PORT = process.env.PORT || 4000;
 const YAHOO_FINANCE_URL =
   'https://query1.finance.yahoo.com/v7/finance/quote?symbols=ZC=F';
 
+const FETCH_OPTIONS = {
+  headers: {
+    'User-Agent':
+      'Mozilla/5.0 (compatible; CornPriceMonitor/1.0; +https://example.com)',
+    Accept: 'application/json',
+    'Accept-Language': 'en-US,en;q=0.9'
+  }
+};
+
 app.use(cors());
 app.use(express.json());
 
@@ -17,7 +26,7 @@ app.get('/api/health', (_req, res) => {
 
 app.get('/api/corn-price', async (_req, res) => {
   try {
-    const response = await fetch(YAHOO_FINANCE_URL);
+    const response = await fetch(YAHOO_FINANCE_URL, FETCH_OPTIONS);
     if (!response.ok) {
       throw new Error(`Failed to fetch price: ${response.status}`);
     }
@@ -40,9 +49,11 @@ app.get('/api/corn-price', async (_req, res) => {
         : new Date().toISOString()
     });
   } catch (error) {
-    console.error('Error fetching corn price', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('Error fetching corn price', message);
     res.status(502).json({
-      error: 'Unable to retrieve corn price at this time. Please try again later.'
+      error: 'Unable to retrieve corn price at this time. Please try again later.',
+      details: message
     });
   }
 });

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,14 +1,50 @@
 import express from 'express';
 import cors from 'cors';
+import fetch from 'node-fetch';
 
 const app = express();
 const PORT = process.env.PORT || 4000;
+
+const YAHOO_FINANCE_URL =
+  'https://query1.finance.yahoo.com/v7/finance/quote?symbols=ZC=F';
 
 app.use(cors());
 app.use(express.json());
 
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok', message: 'Backend is running!' });
+});
+
+app.get('/api/corn-price', async (_req, res) => {
+  try {
+    const response = await fetch(YAHOO_FINANCE_URL);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch price: ${response.status}`);
+    }
+
+    const data = await response.json();
+    const [quote] = data?.quoteResponse?.result ?? [];
+
+    if (!quote) {
+      throw new Error('No corn futures data returned');
+    }
+
+    res.json({
+      symbol: quote.symbol,
+      price: quote.regularMarketPrice,
+      currency: quote.currency,
+      exchange: quote.fullExchangeName,
+      previousClose: quote.regularMarketPreviousClose ?? null,
+      timestamp: quote.regularMarketTime
+        ? new Date(quote.regularMarketTime * 1000).toISOString()
+        : new Date().toISOString()
+    });
+  } catch (error) {
+    console.error('Error fetching corn price', error);
+    res.status(502).json({
+      error: 'Unable to retrieve corn price at this time. Please try again later.'
+    });
+  }
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- add a backend endpoint that proxies Yahoo Finance CBOT corn futures pricing data
- enhance the React dashboard to poll the backend every few seconds and display the latest quote, change, and timestamp
- include the node-fetch dependency required to perform the external API request

## Testing
- npm install *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/cors)*

------
https://chatgpt.com/codex/tasks/task_e_68e085ea4b98833398310f33235a14b0